### PR TITLE
Parameters added to the endpoint of categories

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.3.3 (2017-12-04)
+
+* Parameters added to the endpoints of categories [lccruz]
+
 ## 0.3.2 (2017-10-25)
 
 * Added base Headers in request.

--- a/python_wpapi/python_wpapi.py
+++ b/python_wpapi/python_wpapi.py
@@ -114,8 +114,8 @@ class WpApi():
         endpoint = '{}/taxonomies/{}'.format(self.base_url, slug)
         return self._request(endpoint)
 
-    def get_categories(self):
-        endpoint = '{}/categories'.format(self.base_url)
+    def get_categories(self, parameters='?per_page=10'):
+        endpoint = '{}/categories/{}'.format(self.base_url, parameters)
         return self._request(endpoint)
 
     def get_category(self, id, context='view'):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.2
+current_version = 0.3.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = [
 
 setup(
     name='python_wpapi',
-    version='0.3.2',
+    version='0.3.3',
     description="Simple wrapper around the Wordpress REST API",
     long_description=readme + '\n\n' + history,
     author="Lucas Lobosque",

--- a/tests/test_python_wpapi.py
+++ b/tests/test_python_wpapi.py
@@ -176,7 +176,16 @@ def test_get_taxonomy(mock, api):
 @patch.object(python_wpapi.WpApi, '_request')
 def test_get_categories(mock, api):
     api.get_categories()
-    mock.assert_called_with('http://base.url/wp-json/wp/v2/categories')
+    mock.assert_called_with('http://base.url/wp-json/wp/v2/categories/?per_page=10')
+
+@patch.object(python_wpapi.WpApi, '_request')
+def test_get_categories_with_20_items(mock, api):
+    categories_len = 20
+    mock.return_value = range(categories_len)
+    categories = api.get_categories('?per_page={}'.format(categories_len))
+    url_result = 'http://base.url/wp-json/wp/v2/categories/?per_page={}'.format(categories_len)
+    mock.assert_called_with(url_result)
+    assert len(categories) == categories_len
 
 @patch.object(python_wpapi.WpApi, '_request')
 def test_get_category(mock, api):


### PR DESCRIPTION
By default Wordpress API return 10 categories. So I added optional parameters to the endpoint of categories.